### PR TITLE
add default arg for CacheMeasurer.measure

### DIFF
--- a/src/measurers/cacheMeasurer.ts
+++ b/src/measurers/cacheMeasurer.ts
@@ -6,7 +6,7 @@
 
 import { Cache, d3Selection } from "../utils";
 
-import { IDimensions } from "./abstractMeasurer";
+import { AbstractMeasurer, IDimensions } from "./abstractMeasurer";
 import { CacheCharacterMeasurer } from "./cacheCharacterMeasurer";
 
 export class CacheMeasurer extends CacheCharacterMeasurer {
@@ -23,7 +23,7 @@ export class CacheMeasurer extends CacheCharacterMeasurer {
     return super.measure(s);
   }
 
-  public measure(s: string) {
+  public measure(s: string = AbstractMeasurer.HEIGHT_TEXT) {
     return this.dimCache.get(s);
   }
 

--- a/test/measurerTests.ts
+++ b/test/measurerTests.ts
@@ -104,6 +104,12 @@ describe("Measurer Test Suite", () => {
       assert.deepEqual(dimensions, dimensionsByCharacter, "text has been measured by characters.");
     });
 
+    it("accepts empty measure argument", () => {
+      const expected = measurer.measure(AbstractMeasurer.HEIGHT_TEXT);
+      const actual = (measurer as CacheMeasurer).measure();
+      assert.deepEqual(actual, expected, ".measure() gets passed HEIGHT_TEXT by default");
+    });
+
     afterEach(() => {
       svg.remove();
     });


### PR DESCRIPTION
Keeps the same call signature with the core Measurer.measure