### PR TITLE
reference d3 micro libraries in src

### DIFF
--- a/src/measurers/abstractMeasurer.ts
+++ b/src/measurers/abstractMeasurer.ts
@@ -4,8 +4,6 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
-
 import { d3Selection, DOM } from "../utils";
 
 /**

--- a/src/measurers/characterMeasurer.ts
+++ b/src/measurers/characterMeasurer.ts
@@ -4,7 +4,7 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
+import { max, sum } from "d3-array";
 
 import { IDimensions } from "./abstractMeasurer";
 import { Measurer } from "./measurer";
@@ -18,8 +18,8 @@ export class CharacterMeasurer extends Measurer {
   public _measureLine(line: string): IDimensions {
     const charactersDimensions = line.split("").map((c) => this._measureCharacter(c));
     return {
-      height: d3.max(charactersDimensions, (dim) => dim.height),
-      width: d3.sum(charactersDimensions, (dim) => dim.width),
+      height: max(charactersDimensions, (dim) => dim.height),
+      width: sum(charactersDimensions, (dim) => dim.width),
     };
   }
 }

--- a/src/measurers/measurer.ts
+++ b/src/measurers/measurer.ts
@@ -4,7 +4,7 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
+import { max, sum } from "d3-array";
 
 import { d3Selection } from "../utils";
 
@@ -39,8 +39,8 @@ export class Measurer extends AbstractMeasurer {
 
     const linesDimensions = text.trim().split("\n").map((line) => this._measureLine(line));
     return {
-        height: d3.sum(linesDimensions, (dim) => dim.height),
-        width: d3.max(linesDimensions, (dim) => dim.width),
+        height: sum(linesDimensions, (dim) => dim.height),
+        width: max(linesDimensions, (dim) => dim.width),
       };
   }
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -4,10 +4,10 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
+import { map, Map } from "d3-collection";
 
 export class Cache<T> {
-  private cache: d3.Map<T> = d3.map<T>();
+  private cache: Map<T> = map<T>();
   private compute: (k: string) => T;
 
   /**
@@ -39,7 +39,7 @@ export class Cache<T> {
    * @return {Cache<T>} The calling Cache.
    */
   public clear(): Cache<T> {
-    this.cache = d3.map<T>();
+    this.cache = map<T>();
     return this;
   }
 }

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -4,9 +4,9 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
+import { BaseType, Selection } from "d3-selection";
 
-export type d3Selection<D extends d3.BaseType> = d3.Selection<D, any, any, any>;
+export type d3Selection<D extends BaseType> = Selection<D, any, any, any>;
 
 export class DOM {
   public static transform(s: d3Selection<any>): string;

--- a/test/measurerTests.ts
+++ b/test/measurerTests.ts
@@ -4,7 +4,7 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
+import { max, sum } from "d3-array";
 
 import {
   AbstractMeasurer,
@@ -74,8 +74,8 @@ describe("Measurer Test Suite", () => {
       const dimensions = measurer.measure(text);
       const characterDimensions: IDimensions[] = text.split("").map((c) => measurer.measure(c));
       const dimensionsByCharacter = {
-        height: d3.max(characterDimensions.map((c) => c.height)),
-        width: d3.sum(characterDimensions.map((c) => c.width)),
+        height: max(characterDimensions.map((c) => c.height)),
+        width: sum(characterDimensions.map((c) => c.width)),
       };
 
       assert.deepEqual(dimensions, dimensionsByCharacter, "text has been measured by characters.");
@@ -97,8 +97,8 @@ describe("Measurer Test Suite", () => {
       const dimensions = measurer.measure(text);
       const characterDimensions: IDimensions[] = text.split("").map((c) => measurer.measure(c));
       const dimensionsByCharacter = {
-        height: d3.max(characterDimensions.map((c) => c.height)),
-        width: d3.sum(characterDimensions.map((c) => c.width)),
+        height: max(characterDimensions.map((c) => c.height)),
+        width: sum(characterDimensions.map((c) => c.width)),
       };
 
       assert.deepEqual(dimensions, dimensionsByCharacter, "text has been measured by characters.");

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,9 +4,8 @@
  * license at https://github.com/palantir/svg-typewriter/blob/develop/LICENSE
  */
 
-import * as d3 from "d3";
-
 import { assert } from "chai";
+import { select } from "d3-selection";
 
 import { d3Selection } from "../src";
 
@@ -16,13 +15,13 @@ export function generateSVG(width = 400, height = 400): d3Selection<any> {
 }
 
 export function getSVGParent(): d3Selection<any> {
-  const mocha = d3.select("#mocha-report");
+  const mocha = select("#mocha-report");
   if (mocha.node() != null) {
     const suites: any = mocha.selectAll(".suite");
-    const lastSuite = d3.select(suites[0][suites[0].length - 1]);
+    const lastSuite = select(suites[0][suites[0].length - 1]);
     return lastSuite.selectAll("ul");
   } else {
-    return d3.select("body");
+    return select("body");
   }
 }
 


### PR DESCRIPTION
this prevents bundlers from pulling in the standalone d3/build/d3.js
which lets downstream users pull in d3-selection-multi without there
being two separate d3 instances